### PR TITLE
Add our own version of org.yaml.snakeyaml.inspector.TrustedTagInspector

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.4.4" date="not released">
+      <action type="fix" dev="sseifert"><![CDATA[
+        Add our own version of <code>org.yaml.snakeyaml.inspector.TrustedTagInspector</code> as it was removed from the SnakeYAML codebase with version 2.1.
+      ]]></action>
+    </release>
+
     <release version="1.4.2" date="2023-03-27">
       <action type="update" dev="sseifert">
         Switch to Java 11 as minimum version.

--- a/conga-ansible-plugin/pom.xml
+++ b/conga-ansible-plugin/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>io.wcm.devops.conga</groupId>
       <artifactId>io.wcm.devops.conga.generator</artifactId>
-      <version>1.15.0</version>
+      <version>1.16.2</version>
       <scope>compile</scope>
     </dependency>
 

--- a/conga-ansible-plugin/src/it/example/pom.xml
+++ b/conga-ansible-plugin/src/it/example/pom.xml
@@ -65,7 +65,7 @@
       <plugin>
         <groupId>io.wcm.devops.conga</groupId>
         <artifactId>conga-maven-plugin</artifactId>
-        <version>1.15.0</version>
+        <version>1.16.2</version>
         <extensions>true</extensions>
         <configuration>
           <valueProvider>

--- a/conga-ansible-plugin/src/main/java/org/yaml/snakeyaml/inspector/TrustedTagInspector.java
+++ b/conga-ansible-plugin/src/main/java/org/yaml/snakeyaml/inspector/TrustedTagInspector.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008, SnakeYAML
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.yaml.snakeyaml.inspector;
+
+import org.yaml.snakeyaml.nodes.Tag;
+
+/**
+ * TagInspector which allows to create any custom instance. Should not be used when the data comes
+ * from untrusted source to prevent possible remote code invocation.
+ */
+public final class TrustedTagInspector implements TagInspector {
+
+  /**
+   * Allow any
+   *
+   * @param tag - the global tag to allow
+   * @return always return true
+   */
+  @Override
+  public boolean isGlobalTagAllowed(Tag tag) {
+    return true;
+  }
+}


### PR DESCRIPTION
as it was removed from the SnakeYAML codebase with version 2.1.